### PR TITLE
py27 compatibility

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,4 @@
+[TYPECHECK]
+# Note: This modules are manipulated during the runtime so we can't detect all the properties during
+# static analysis
+ignored-modules=six,six.moves

--- a/run_pylint.sh
+++ b/run_pylint.sh
@@ -1,2 +1,2 @@
 echo "Running pylint"
-find src/opsgenie -name "*.py" -exec pylint -E {} \+
+find src/opsgenie -name "*.py" -exec pylint -E --rcfile=./.pylintrc {} \+

--- a/src/opsgenie/alert.py
+++ b/src/opsgenie/alert.py
@@ -2,7 +2,7 @@ from .resource import BaseResource
 
 class AlertResource(BaseResource):
     id_params = ["id", "alias", "tinyId"]
-    
+
     #Opsgenie uses inconsisten naming  /sigh
     alert_id_params = ["alertId", "alias"]
 

--- a/src/opsgenie/api.py
+++ b/src/opsgenie/api.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from six.moves.urllib.parse import urljoin
 
 import requests
 
@@ -30,7 +30,7 @@ class OpsGenieAPI:
             path=path[1:]
         path = path.replace("//", "/")
         return urljoin(self.url_base, path)
-    
+
     def get(self, path, params={}, process_opts={}):
         url = self.get_url(path)
         params["apiKey"] = self.api_key

--- a/src/opsgenie/resource.py
+++ b/src/opsgenie/resource.py
@@ -1,8 +1,9 @@
-from urllib.parse import urljoin
+from six.moves.urllib.parse import urljoin
+
 
 class BaseResource:
     """Provides a common base for resource classes
-    
+
     Resources inheriting this must set self.path and self.api
     """
     path = None

--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -1,12 +1,12 @@
 import json
 import random
 import unittest
-import urllib
 import uuid
 
 import fauxfactory
 import responses
 
+from six.moves.urllib import parse
 from opsgenie.api import OpsGenieAPI
 
 class TestAlertResource(unittest.TestCase):
@@ -38,7 +38,7 @@ class TestAlertResource(unittest.TestCase):
     def test_update(self):
         alert_id = str(uuid.uuid4())
         response_body = json.dumps(
-            {'message': 'alert created', 'code': 200, 'status': 'successful', 
+            {'message': 'alert created', 'code': 200, 'status': 'successful',
             'alertId': alert_id, 'took': 126})
         with responses.RequestsMock() as requests_mock:
             requests_mock.add(
@@ -72,8 +72,8 @@ class TestAlertResource(unittest.TestCase):
             )
             alert_result = self.resource.get(id=alert_id)
             alert_request = requests_mock.calls[0].request
-            query_string = urllib.parse.urlparse(alert_request.path_url).query
-            request_params = urllib.parse.parse_qs(query_string)
+            query_string = parse.urlparse(alert_request.path_url).query
+            request_params = parse.parse_qs(query_string)
             self.assertEqual(request_params["id"][0], alert_id)
             for alert_key, alert_val in fake_alert.items():
                 self.assertEqual(alert_result[alert_key], alert_val)
@@ -81,7 +81,7 @@ class TestAlertResource(unittest.TestCase):
     def test_get_id_error(self):
         with self.assertRaises(ValueError):
             self.resource.get()
-            
+
     def test_list(self):
         fake_alerts_list = [self.generate_fake_alert() for x in range(0, random.randint(0,5))]
         with responses.RequestsMock() as requests_mock:
@@ -97,8 +97,8 @@ class TestAlertResource(unittest.TestCase):
             alerts_response = self.api.get_resource("alert").list(status="unacked")
             alerts_request = requests_mock.calls[0].request
             self.assertEqual(len(requests_mock.calls), 1)
-            query_string = urllib.parse.urlparse(alerts_request.path_url).query
-            request_params = urllib.parse.parse_qs(query_string)
+            query_string = parse.urlparse(alerts_request.path_url).query
+            request_params = parse.parse_qs(query_string)
             self.assertEqual(request_params["status"][0], "unacked")
             self.assertEqual(alerts_response, fake_alerts_list)
 
@@ -176,8 +176,8 @@ class TestAlertResource(unittest.TestCase):
     def test_add_recipient_id_error(self):
         with self.assertRaises(ValueError):
             self.resource.add_recipient("foo", tinyId=1234)
-            
-        
+
+
     def generate_fake_alert(self, **set_values):
         alert = {
             "id":str(uuid.uuid4()),
@@ -185,13 +185,13 @@ class TestAlertResource(unittest.TestCase):
             "message":fauxfactory.gen_string("alphanumeric", random.randint(1,130)),
             "alias":fauxfactory.gen_string("alphanumeric", random.randint(1,30)),
             "description":fauxfactory.gen_string("alphanumeric", random.randint(1,15000)),
-            "recipients":[fauxfactory.gen_string("alphanumeric", random.randint(1,30)) 
+            "recipients":[fauxfactory.gen_string("alphanumeric", random.randint(1,30))
                 for x in range(0, random.randint(0,5))],
             #No actions at this time check back later
             "source":fauxfactory.gen_string("alphanumeric", random.randint(1,30)),
             "tags":",".join([fauxfactory.gen_string("alphanumeric", random.randint(1,30))
                 for x in range(0, random.randint(0,5))]),
-            "details":{fauxfactory.gen_string("alphanumeric", random.randint(1,30)): 
+            "details":{fauxfactory.gen_string("alphanumeric", random.randint(1,30)):
                 fauxfactory.gen_string("alphanumeric", random.randint(1,30)) for x in range(
                     0, random.randint(0,5))},
             "entity":fauxfactory.gen_string("alphanumeric", random.randint(1,30)),
@@ -202,4 +202,4 @@ class TestAlertResource(unittest.TestCase):
             alert[sey_key] = set_val
         return alert
 
-        
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,17 @@
 [tox]
-envlist = py34
+envlist = py34, py27
 skipsdist=True
 
 [testenv]
 deps=
+    six
     nose2
     pylint
     git+https://github.com/getsentry/responses.git
     fauxfactory
 setenv =
     PYTHONPATH = {toxinidir}/tests/
-commands = 
+commands =
     python setup.py install
     nose2 -s tests/
     /bin/sh -c "./run_pylint.sh"


### PR DESCRIPTION
* py27 compatibilty requires using six so that the moved modules work
  from both py34 and py27
* pylint has trouble with six.moves requiring it to ignore imports from
  six and six.moves